### PR TITLE
Tweak tokio chat example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,3 +123,7 @@ members = [
     "transports/websocket",
     "transports/wasm-ext"
 ]
+
+[[example]]
+name = "chat-tokio"
+required-features = ["tcp-tokio", "mdns-tokio"]


### PR DESCRIPTION
I used the `required-features` here to make sure the tokio chat example can only be run with tokio. I also clarified the documentation a bit and reduced the code to use only what is necessary for the example, including explicitly creating a tokio-based TCP transport, rather than using `build_development_transport()` which is a bit too opaque if we want to show clearly what using tokio entails. Let me know what you think.